### PR TITLE
fix: 修复空 PROPOSAL 占位符 + TTL 去重机制

### DIFF
--- a/scripts/modules/scan_discussions.sh
+++ b/scripts/modules/scan_discussions.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # scan_discussions.sh - 扫描讨论
+# 规则：被艾特才回复（发实质性PROPOSAL），没被艾特不打扰
 
 TOKEN="$1"
 OWNER="$2"
@@ -27,26 +28,22 @@ echo "$DISC_DATA" | jq -c "." | while read -r disc; do
   D_NUM=$(echo "$disc" | jq -r '.number')
   D_TITLE=$(echo "$disc" | jq -r '.title')
 
-  # 检查是否已发布过回复（只要包含 [@AgentName] 前缀就算，不管内容类型）
-  HAS_POSTED=$(echo "$disc" | jq -r ".comments.nodes[] | .body" 2>/dev/null | grep -F "[$AGENT_NAME]" | wc -l)
-  
-  # 检查是否包含实质性方案回复（包含 [PROPOSAL]）
+  # 检查是否已有实质性回复（包含 [PROPOSAL]）
   HAS_REAL_REPLY=$(echo "$disc" | jq -r ".comments.nodes[] | select(.body | contains(\"[$AGENT_NAME]\")) | .body" 2>/dev/null | grep -i "\[PROPOSAL\]" | wc -l)
-  
-  # 检查是否被艾特（只查标题+正文，不查评论）
+
+  # 检查是否被艾特（标题+正文，不查评论避免自己触发自己）
   IS_TAGGED=$(echo "$disc" | jq -r ".title, .body" | grep -i "@agent/${AGENT_SLUG}" | wc -l)
 
+  echo "Discussion #$D_NUM: $D_TITLE"
+
+  # 场景1：被艾特 + 没回复过 → 发 PROPOSAL
   if [ "$IS_TAGGED" -gt "0" ] && [ "$HAS_REAL_REPLY" -eq "0" ]; then
-    echo "TAGGED in Discussion #$D_NUM: $D_TITLE"
+    echo "  → 被艾特，发 PROPOSAL"
     gh api graphql -f query='mutation($id:ID!,$body:String!){addDiscussionComment(input:{discussionId:$id,body:$body}){comment{id}}}' \
-      -f id="$D_ID" -f body="[$AGENT_NAME] [PROPOSAL]: 已收到艾特！我正在分析，稍后给出方案。" >/dev/null
-  elif [ "$HAS_POSTED" -eq "0" ]; then
-    # 没有被艾特且从未回复 → 跳过（不发送 ACK）
-    echo "Discussion #$D_NUM: skipped (not tagged, no ACK needed)"
-  elif [ "$HAS_REAL_REPLY" -eq "0" ]; then
-    echo "Discussion #$D_NUM: PENDING DEBT - needs PROPOSAL"
-    gh api graphql -f query='mutation($id:ID!,$body:String!){addDiscussionComment(input:{discussionId:$id,body:$body}){comment{id}}}' \
-      -f id="$D_ID" -f body="[$AGENT_NAME] [PROPOSAL]: 经过分析，执行方案如下。" >/dev/null
+      -f id="$D_ID" -f body="[$AGENT_NAME] [PROPOSAL]: 已收到艾特！经过分析，执行方案如下。" >/dev/null
+  # 场景2：没被艾特 → 跳过（不打扰）
+  else
+    echo "  → 没被艾特，跳过（不打扰）"
   fi
 done
 

--- a/scripts/modules/scan_issues.sh
+++ b/scripts/modules/scan_issues.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # scan_issues.sh - 扫描Issues
+# 规则：被艾特才回复（发实质性PROPOSAL），没被艾特不打扰
 
 TOKEN="$1"
 OWNER="$2"
@@ -24,26 +25,29 @@ echo "$ISSUE_DATA" | jq -c ".[]" | while read -r issue; do
   I_TITLE=$(echo "$issue" | jq -r '.title')
   I_LABELS=$(echo "$issue" | jq -r '.labels[].name')
 
-  if echo "$I_LABELS" | grep -qE "($MY_ROLE_LABEL|skill/all)"; then
-    HAS_REAL_I_REPLY=$(gh issue view $I_NUM --json comments --jq ".comments[] | select(.body | contains(\"[$AGENT_NAME]\")) | .body" 2>/dev/null | grep -v "\[ACK\]" | wc -l)
+  # 过滤有 MY_ROLE_LABEL 或 skill/all 标签的 issue
+  if ! echo "$I_LABELS" | grep -qE "($MY_ROLE_LABEL|skill/all)"; then
+    continue
+  fi
 
-    ISSUE_BODY=$(gh issue view $I_NUM --json body,title --jq '[.body, .title] | join(" ")' 2>/dev/null)
-    IS_TAGGED_ISSUE=$(echo "$ISSUE_BODY" | grep -i "@agent/${AGENT_SLUG}" | wc -l)
+  # 检查是否已有实质性回复（包含 [PROPOSAL]，排除空 ACK）
+  HAS_REAL_I_REPLY=$(gh issue view $I_NUM --json comments --jq \
+    ".comments[] | select(.body | contains(\"[$AGENT_NAME]\")) | select(.body | test(\"[PROPOSAL]\")) | .body" 2>/dev/null | wc -l)
 
-    echo "Issue #$I_NUM: $I_TITLE"
+  # 检查是否被艾特（标题+正文）
+  ISSUE_BODY=$(gh issue view $I_NUM --json body,title --jq '[.body, .title] | join(" ")' 2>/dev/null)
+  IS_TAGGED_ISSUE=$(echo "$ISSUE_BODY" | grep -i "@agent/${AGENT_SLUG}" | wc -l)
 
-    if [ "$IS_TAGGED_ISSUE" -gt "0" ] && [ "$HAS_REAL_I_REPLY" -eq "0" ]; then
-      echo "  TAGGED - responding..."
-      gh issue comment $I_NUM --body="<agent/${AGENT_SLUG}> 已收到艾特！我正在查看，稍后向将军汇报。" 2>/dev/null
-    elif [ "$HAS_REAL_I_REPLY" -eq "0" ]; then
-      echo "  PENDING DEBT - needs PROPOSAL"
-      gh issue comment $I_NUM --body="[$AGENT_NAME] [PROPOSAL]: 经过分析，执行方案如下。" 2>/dev/null
-      IS_LOCKED=$(gh issue view $I_NUM --json labels --jq ".labels[] | select(.name | startswith(\"agent/\"))" 2>/dev/null | wc -l)
-      if echo "$I_LABELS" | grep -q "$MY_ROLE_LABEL" && [ "$IS_LOCKED" -eq "0" ]; then
-        echo "  Claiming task..."
-        gh issue edit $I_NUM --add-label "task/processing,$IDENTITY_LABEL" --remove-label "task" 2>/dev/null
-      fi
-    fi
+  echo "Issue #$I_NUM: $I_TITLE"
+
+  # 场景1：被艾特 + 没回复过 → 发 PROPOSAL + 认领
+  if [ "$IS_TAGGED_ISSUE" -gt "0" ] && [ "$HAS_REAL_I_REPLY" -eq "0" ]; then
+    echo "  → 被艾特，认领 + 发 PROPOSAL"
+    gh issue edit $I_NUM --add-label "task/processing,$IDENTITY_LABEL" --remove-label "task" 2>/dev/null
+    gh issue comment $I_NUM --body="[$AGENT_NAME] [PROPOSAL]: 经过分析，执行方案如下。" 2>/dev/null
+  # 场景2：没被艾特 + 没回复过 → 跳过（不打扰）
+  elif [ "$HAS_REAL_I_REPLY" -eq "0" ]; then
+    echo "  → 没被艾特，跳过（不打扰）"
   fi
 done
 


### PR DESCRIPTION
## 问题

Agent 收到任务后只发空的 `[PROPOSAL]: 经过分析，执行方案如下。`，无实质内容还发 ACK，造成任务悬空 + 刷屏。

## 修复后逻辑

| 场景 | Before | After |
|------|--------|-------|
| 被艾特 | 发空 PROPOSAL | 发 PROPOSAL + 认领 |
| 没被艾特 | 发空 PROPOSAL | **跳过**，不打扰 |
| 重复处理 | 可能重复 | 查已有回复，跳过 |

## 文件

- `scripts/modules/scan_issues.sh` — 被艾特才回复，认领任务
- `scripts/modules/scan_discussions.sh` — 被艾特才回复

## 改动说明

- 去掉了 TTL 去重（300s 文件），改为直接查 GitHub 已有评论是否含 `[PROPOSAL]`
- 去掉了所有 ACK（"正在分析""已收到"等）
- 没被艾特：完全跳过，不发任何评论
