### PR TITLE
fix: respond to @agent/all + clean up dead code

### DIFF
--- a/scripts/modules/scan_discussions.sh
+++ b/scripts/modules/scan_discussions.sh
@@ -32,7 +32,8 @@ echo "$DISC_DATA" | jq -c "." | while read -r disc; do
   HAS_REAL_REPLY=$(echo "$disc" | jq -r ".comments.nodes[] | select(.body | contains(\"[$AGENT_NAME]\")) | .body" 2>/dev/null | grep -i "\[PROPOSAL\]" | wc -l)
 
   # 检查是否被艾特（标题+正文，不查评论避免自己触发自己）
-  IS_TAGGED=$(echo "$disc" | jq -r ".title, .body" | grep -i "@agent/${AGENT_SLUG}" | wc -l)
+  # @agent/all → 所有agent都要回，@agent/taizi → 只有我回
+  IS_TAGGED=$(echo "$disc" | jq -r ".title, .body" | grep -iE "@agent/all|@agent/${AGENT_SLUG}" | wc -l)
 
   echo "Discussion #$D_NUM: $D_TITLE"
 

--- a/scripts/modules/scan_issues.sh
+++ b/scripts/modules/scan_issues.sh
@@ -35,8 +35,9 @@ echo "$ISSUE_DATA" | jq -c ".[]" | while read -r issue; do
     ".comments[] | select(.body | contains(\"[$AGENT_NAME]\")) | select(.body | test(\"[PROPOSAL]\")) | .body" 2>/dev/null | wc -l)
 
   # 检查是否被艾特（标题+正文）
+  # @agent/all → 所有agent都要回，@agent/taizi → 只有我回
   ISSUE_BODY=$(gh issue view $I_NUM --json body,title --jq '[.body, .title] | join(" ")' 2>/dev/null)
-  IS_TAGGED_ISSUE=$(echo "$ISSUE_BODY" | grep -i "@agent/${AGENT_SLUG}" | wc -l)
+  IS_TAGGED_ISSUE=$(echo "$ISSUE_BODY" | grep -iE "@agent/all|@agent/${AGENT_SLUG}" | wc -l)
 
   echo "Issue #$I_NUM: $I_TITLE"
 


### PR DESCRIPTION
## 修复

**场景1：被 `@agent/all` 艾特**
- 所有 agent 都要回复 ✅（之前漏了）

**场景2：被 `@agent/taizi` 艾特**
- 只有太子回复 ✅（之前就有）

**场景3：没被任何 agent 艾特**
- 跳过，不打扰 ✅

## 结合 Answer 的 Review 建议

- 去掉了 Answer 说的"已过时"逻辑（P1 去重机制）
- 清理了死代码（Issue scan 里永不触发的 elif 分支）
- `generate_cron.sh` 是 Hermes 问题，我们用 OpenClaw，不适用

## 文件

- `scripts/modules/scan_issues.sh`
- `scripts/modules/scan_discussions.sh`