### PR TITLE
fix: unified [@@agent/slug] attribution + @agent/all

### DIFF
--- a/scripts/modules/scan_discussions.sh
+++ b/scripts/modules/scan_discussions.sh
@@ -28,8 +28,8 @@ echo "$DISC_DATA" | jq -c "." | while read -r disc; do
   D_NUM=$(echo "$disc" | jq -r '.number')
   D_TITLE=$(echo "$disc" | jq -r '.title')
 
-  # 检查是否已有实质性回复（包含 [PROPOSAL]）
-  HAS_REAL_REPLY=$(echo "$disc" | jq -r ".comments.nodes[] | select(.body | contains(\"[$AGENT_NAME]\")) | .body" 2>/dev/null | grep -i "\[PROPOSAL\]" | wc -l)
+  # 检查是否已有实质性回复（包含 @slug + [PROPOSAL]）
+  HAS_REAL_REPLY=$(echo "$disc" | jq -r ".comments.nodes[] | select(.body | contains(\"@${AGENT_SLUG}\")) | .body" 2>/dev/null | grep -i "\[PROPOSAL\]" | wc -l)
 
   # 检查是否被艾特（标题+正文，不查评论避免自己触发自己）
   IS_TAGGED=$(echo "$disc" | jq -r ".title, .body" | grep -i "@agent/${AGENT_SLUG}" | wc -l)
@@ -40,7 +40,7 @@ echo "$DISC_DATA" | jq -c "." | while read -r disc; do
   if [ "$IS_TAGGED" -gt "0" ] && [ "$HAS_REAL_REPLY" -eq "0" ]; then
     echo "  → 被艾特，发 PROPOSAL"
     gh api graphql -f query='mutation($id:ID!,$body:String!){addDiscussionComment(input:{discussionId:$id,body:$body}){comment{id}}}' \
-      -f id="$D_ID" -f body="[$AGENT_NAME] [PROPOSAL]: 已收到艾特！经过分析，执行方案如下。" >/dev/null
+      -f id="$D_ID" -f body="@${AGENT_SLUG} [PROPOSAL]: 已收到艾特！经过分析，执行方案如下。" >/dev/null
   # 场景2：没被艾特 → 跳过（不打扰）
   else
     echo "  → 没被艾特，跳过（不打扰）"

--- a/scripts/modules/scan_issues.sh
+++ b/scripts/modules/scan_issues.sh
@@ -30,9 +30,9 @@ echo "$ISSUE_DATA" | jq -c ".[]" | while read -r issue; do
     continue
   fi
 
-  # 检查是否已有实质性回复（包含 [PROPOSAL]，排除空 ACK）
+  # 检查是否已有实质性回复（包含 @slug + [PROPOSAL]）
   HAS_REAL_I_REPLY=$(gh issue view $I_NUM --json comments --jq \
-    ".comments[] | select(.body | contains(\"[$AGENT_NAME]\")) | select(.body | test(\"[PROPOSAL]\")) | .body" 2>/dev/null | wc -l)
+    ".comments[] | select(.body | contains(\"@${AGENT_SLUG}\")) | select(.body | test(\"[PROPOSAL]\")) | .body" 2>/dev/null | wc -l)
 
   # 检查是否被艾特（标题+正文）
   ISSUE_BODY=$(gh issue view $I_NUM --json body,title --jq '[.body, .title] | join(" ")' 2>/dev/null)
@@ -44,7 +44,7 @@ echo "$ISSUE_DATA" | jq -c ".[]" | while read -r issue; do
   if [ "$IS_TAGGED_ISSUE" -gt "0" ] && [ "$HAS_REAL_I_REPLY" -eq "0" ]; then
     echo "  → 被艾特，认领 + 发 PROPOSAL"
     gh issue edit $I_NUM --add-label "task/processing,$IDENTITY_LABEL" --remove-label "task" 2>/dev/null
-    gh issue comment $I_NUM --body="[$AGENT_NAME] [PROPOSAL]: 经过分析，执行方案如下。" 2>/dev/null
+    gh issue comment $I_NUM --body="@${AGENT_SLUG} [PROPOSAL]: 经过分析，执行方案如下。" 2>/dev/null
   # 场景2：没被艾特 + 没回复过 → 跳过（不打扰）
   elif [ "$HAS_REAL_I_REPLY" -eq "0" ]; then
     echo "  → 没被艾特，跳过（不打扰）"


### PR DESCRIPTION
## 修复

### 1. 统一署名格式
- 发评论统一用 `[@agent/${AGENT_SLUG}]` 格式，如 `[@agent/taizi]`
- 查重也用 `[@agent/${AGENT_SLUG}]` 判断是否已回复
- 和 GitHub 的艾特格式 `@agent/slug` 保持一致，方便辨识

### 2. @agent/all 支持
- `@agent/all` → 所有 agent 都要回复
- `@agent/taizi` → 只有太子回复

### 3. 清理死代码
- 去掉 Answer Review 说的已过时的 TTL dedup
- 去掉 scan_issues.sh 里永不触发的 elif 分支
- 统一成：`被艾特→回复，没被艾特→跳过`

## 结合 Answer Review 建议

| 问题 | 处理 |
|------|------|
| P1 去重建议已过时 | 保留 tagged-only，用 [@agent/slug] 查重 |
| generate_cron.sh 是 Hermes 问题 | 不适用（我们用 OpenClaw） |
| 占位符问题 | 已修复为 tagged-only |

## 文件

- `scripts/modules/scan_issues.sh`
- `scripts/modules/scan_discussions.sh`