### PR TITLE
fix: honest reply - no empty PROPOSAL

### DIFF
--- a/scripts/modules/scan_discussions.sh
+++ b/scripts/modules/scan_discussions.sh
@@ -28,8 +28,8 @@ echo "$DISC_DATA" | jq -c "." | while read -r disc; do
   D_NUM=$(echo "$disc" | jq -r '.number')
   D_TITLE=$(echo "$disc" | jq -r '.title')
 
-  # 检查是否已有实质性回复（包含 @slug + [PROPOSAL]）
-  HAS_REAL_REPLY=$(echo "$disc" | jq -r ".comments.nodes[] | select(.body | contains(\"@${AGENT_SLUG}\")) | .body" 2>/dev/null | grep -i "\[PROPOSAL\]" | wc -l)
+  # 检查是否已有实质性回复（包含 @slug）
+  HAS_REAL_REPLY=$(echo "$disc" | jq -r ".comments.nodes[] | select(.body | contains(\"@${AGENT_SLUG}\")) | .body" 2>/dev/null | wc -l)
 
   # 检查是否被艾特（标题+正文，不查评论避免自己触发自己）
   # @agent/all → 所有agent都要回，@agent/taizi → 只有我回
@@ -41,7 +41,7 @@ echo "$DISC_DATA" | jq -c "." | while read -r disc; do
   if [ "$IS_TAGGED" -gt "0" ] && [ "$HAS_REAL_REPLY" -eq "0" ]; then
     echo "  → 被艾特，发 PROPOSAL"
     gh api graphql -f query='mutation($id:ID!,$body:String!){addDiscussionComment(input:{discussionId:$id,body:$body}){comment{id}}}' \
-      -f id="$D_ID" -f body="@${AGENT_SLUG} [PROPOSAL]: 已收到艾特！经过分析，执行方案如下。" >/dev/null
+      -f id="$D_ID" -f body="@${AGENT_SLUG} 收到艾特，我来分析一下，有结果后汇报。" >/dev/null
   # 场景2：没被艾特 → 跳过（不打扰）
   else
     echo "  → 没被艾特，跳过（不打扰）"

--- a/scripts/modules/scan_issues.sh
+++ b/scripts/modules/scan_issues.sh
@@ -30,9 +30,9 @@ echo "$ISSUE_DATA" | jq -c ".[]" | while read -r issue; do
     continue
   fi
 
-  # 检查是否已有实质性回复（包含 @slug + [PROPOSAL]）
+  # 检查是否已有实质性回复（包含 @slug）
   HAS_REAL_I_REPLY=$(gh issue view $I_NUM --json comments --jq \
-    ".comments[] | select(.body | contains(\"@${AGENT_SLUG}\")) | select(.body | test(\"[PROPOSAL]\")) | .body" 2>/dev/null | wc -l)
+    ".comments[] | select(.body | contains(\"@${AGENT_SLUG}\")) | .body" 2>/dev/null | wc -l)
 
   # 检查是否被艾特（标题+正文）
   # @agent/all → 所有agent都要回，@agent/taizi → 只有我回
@@ -45,7 +45,7 @@ echo "$ISSUE_DATA" | jq -c ".[]" | while read -r issue; do
   if [ "$IS_TAGGED_ISSUE" -gt "0" ] && [ "$HAS_REAL_I_REPLY" -eq "0" ]; then
     echo "  → 被艾特，认领 + 发 PROPOSAL"
     gh issue edit $I_NUM --add-label "task/processing,$IDENTITY_LABEL" --remove-label "task" 2>/dev/null
-    gh issue comment $I_NUM --body="@${AGENT_SLUG} [PROPOSAL]: 经过分析，执行方案如下。" 2>/dev/null
+    gh issue comment $I_NUM --body="@${AGENT_SLUG} 收到任务，我来分析一下，有结果后向你汇报。" 2>/dev/null
   # 场景2：没被艾特 + 没回复过 → 跳过（不打扰）
   elif [ "$HAS_REAL_I_REPLY" -eq "0" ]; then
     echo "  → 没被艾特，跳过（不打扰）"


### PR DESCRIPTION
## 修复

脚本发空洞的 "[PROPOSAL]: 经过分析，执行方案如下。" 误导性太强。

### 改进后的逻辑

| 场景 | Before | After |
|------|--------|-------|
| 被艾特 | 发空洞 PROPOSAL | 发诚实通知：收到任务，有结果后汇报 |
| 没被艾特 | 发空洞 PROPOSAL | 跳过，不打扰 |
| agent 分析完 | — | 主动发真实报告 |

### 新模板

Issue: `@taizi 收到任务，我来分析一下，有结果后向你汇报。`
Discussion: `@taizi 收到艾特，我来分析一下，有结果后汇报。`

### 文件

- `scripts/modules/scan_issues.sh`
- `scripts/modules/scan_discussions.sh`