### PR TITLE
fix: respond to skill/all label (broadcast)

### DIFF
--- a/scripts/modules/scan_discussions.sh
+++ b/scripts/modules/scan_discussions.sh
@@ -14,7 +14,7 @@ export GITHUB_TOKEN="$TOKEN"
 
 echo "Scanning discussions..."
 
-DISC_QUERY='query($owner:String!,$repo:String!){repository(owner:$owner,name:$repo){discussions(first:10,orderBy:{field:CREATED_AT,direction:DESC}){nodes{id,number,title,body,comments(last:20){nodes{author{login},body}}}}}}'
+DISC_QUERY='query($owner:String!,$repo:String!){repository(owner:$owner,name:$repo){discussions(first:10,orderBy:{field:CREATED_AT,direction:DESC}){nodes{id,number,title,body,labels(first:10){nodes{name}},comments(last:20){nodes{author{login},body}}}}}}'
 
 DISC_DATA=$(gh api graphql -f owner="$OWNER" -f repo="$REPO_NAME" -f query="$DISC_QUERY" --jq ".data.repository.discussions.nodes[]" 2>/dev/null)
 
@@ -35,16 +35,23 @@ echo "$DISC_DATA" | jq -c "." | while read -r disc; do
   # @agent/all → 所有agent都要回，@agent/taizi → 只有我回
   IS_TAGGED=$(echo "$disc" | jq -r ".title, .body" | grep -iE "@agent/all|@agent/${AGENT_SLUG}" | wc -l)
 
+  # skill/all label 也视为被艾特（全员广播）
+  D_LABELS=$(echo "$disc" | jq -r ".labels.nodes[].name" 2>/dev/null)
+  HAS_SKILL_ALL=$(echo "$D_LABELS" | grep -c "skill/all" || true)
+
   echo "Discussion #$D_NUM: $D_TITLE"
 
-  # 场景1：被艾特 + 没回复过 → 发 PROPOSAL
-  if [ "$IS_TAGGED" -gt "0" ] && [ "$HAS_REAL_REPLY" -eq "0" ]; then
-    echo "  → 被艾特，发 PROPOSAL"
+  # 触发条件：被@ 或 有 skill/all label
+  SHOULD_RESPOND=$((IS_TAGGED + HAS_SKILL_ALL))
+
+  # 场景1：触发 + 没回复过 → 发诚实通知
+  if [ "$SHOULD_RESPOND" -gt "0" ] && [ "$HAS_REAL_REPLY" -eq "0" ]; then
+    echo "  → 触发（tagged=${IS_TAGGED}, skill/all=${HAS_SKILL_ALL}），发通知"
     gh api graphql -f query='mutation($id:ID!,$body:String!){addDiscussionComment(input:{discussionId:$id,body:$body}){comment{id}}}' \
       -f id="$D_ID" -f body="@${AGENT_SLUG} 收到艾特，我来分析一下，有结果后汇报。" >/dev/null
-  # 场景2：没被艾特 → 跳过（不打扰）
+  # 场景2：没触发 → 跳过（不打扰）
   else
-    echo "  → 没被艾特，跳过（不打扰）"
+    echo "  → 没被艾特且无 skill/all，跳过（不打扰）"
   fi
 done
 

--- a/scripts/modules/scan_issues.sh
+++ b/scripts/modules/scan_issues.sh
@@ -39,16 +39,22 @@ echo "$ISSUE_DATA" | jq -c ".[]" | while read -r issue; do
   ISSUE_BODY=$(gh issue view $I_NUM --json body,title --jq '[.body, .title] | join(" ")' 2>/dev/null)
   IS_TAGGED_ISSUE=$(echo "$ISSUE_BODY" | grep -iE "@agent/all|@agent/${AGENT_SLUG}" | wc -l)
 
+  # skill/all label 也视为被艾特（全员广播）
+  HAS_SKILL_ALL=$(echo "$I_LABELS" | grep -c "skill/all" || true)
+
   echo "Issue #$I_NUM: $I_TITLE"
 
-  # 场景1：被艾特 + 没回复过 → 发 PROPOSAL + 认领
-  if [ "$IS_TAGGED_ISSUE" -gt "0" ] && [ "$HAS_REAL_I_REPLY" -eq "0" ]; then
-    echo "  → 被艾特，认领 + 发 PROPOSAL"
+  # 触发条件：被@ 或 有 skill/all label
+  SHOULD_RESPOND=$((IS_TAGGED_ISSUE + HAS_SKILL_ALL))
+
+  # 场景1：触发 + 没回复过 → 发诚实通知 + 认领
+  if [ "$SHOULD_RESPOND" -gt "0" ] && [ "$HAS_REAL_I_REPLY" -eq "0" ]; then
+    echo "  → 触发（tagged=${IS_TAGGED_ISSUE}, skill/all=${HAS_SKILL_ALL}），认领 + 发通知"
     gh issue edit $I_NUM --add-label "task/processing,$IDENTITY_LABEL" --remove-label "task" 2>/dev/null
     gh issue comment $I_NUM --body="@${AGENT_SLUG} 收到任务，我来分析一下，有结果后向你汇报。" 2>/dev/null
-  # 场景2：没被艾特 + 没回复过 → 跳过（不打扰）
+  # 场景2：没触发 + 没回复过 → 跳过（不打扰）
   elif [ "$HAS_REAL_I_REPLY" -eq "0" ]; then
-    echo "  → 没被艾特，跳过（不打扰）"
+    echo "  → 没被艾特且无 skill/all，跳过（不打扰）"
   fi
 done
 


### PR DESCRIPTION
**问题**: Issue #62 是  label 的全员广播，但脚本只看 @agent/all 文字，漏掉了没写 @agent/all 的全员任务。

**修复内容**:
1.  / : 新增  label 检测，触发条件改为
2. : GraphQL 查询补上  字段

**触发条件**:
-  → 太子的任务
-  → 所有 agent 都回
-  label → 所有 agent 都回（广播任务）

哥哥授权自行合并 ✅