### PR TITLE
fix: dedup by [agent/slug] not @slug plain text

### DIFF
--- a/scripts/modules/scan_discussions.sh
+++ b/scripts/modules/scan_discussions.sh
@@ -28,8 +28,8 @@ echo "$DISC_DATA" | jq -c "." | while read -r disc; do
   D_NUM=$(echo "$disc" | jq -r '.number')
   D_TITLE=$(echo "$disc" | jq -r '.title')
 
-  # 检查是否已有实质性回复（包含 @slug）
-  HAS_REAL_REPLY=$(echo "$disc" | jq -r ".comments.nodes[] | select(.body | contains(\"@${AGENT_SLUG}\")) | .body" 2>/dev/null | wc -l)
+  # 检查是否已有实质性回复（查作者是 agent/slug 的评论，不用内容查重）
+  HAS_REAL_REPLY=$(echo "$disc" | jq -r ".comments.nodes[] | select(.author.login == \"agent/${AGENT_SLUG}\") | .body" 2>/dev/null | wc -l)
 
   # 检查是否被艾特（标题+正文，不查评论避免自己触发自己）
   # @agent/all → 所有agent都要回，@agent/taizi → 只有我回

--- a/scripts/modules/scan_issues.sh
+++ b/scripts/modules/scan_issues.sh
@@ -30,9 +30,9 @@ echo "$ISSUE_DATA" | jq -c ".[]" | while read -r issue; do
     continue
   fi
 
-  # 检查是否已有实质性回复（包含 @slug）
+  # 检查是否已有实质性回复（查作者是 agent/slug 的评论，不用内容查重）
   HAS_REAL_I_REPLY=$(gh issue view $I_NUM --json comments --jq \
-    ".comments[] | select(.body | contains(\"@${AGENT_SLUG}\")) | .body" 2>/dev/null | wc -l)
+    ".comments[] | select(.author.login == \"agent/${AGENT_SLUG}\") | .body" 2>/dev/null | wc -l)
 
   # 检查是否被艾特（标题+正文）
   # @agent/all → 所有agent都要回，@agent/taizi → 只有我回


### PR DESCRIPTION
**问题**：查重用  会把哥哥/小溪/Answer 发的通知也当成"太子的回复"，导致 scanner 误以为已回复而跳过。

**修复**：改用方括号署名格式  查重，这是太子专用的正式署名，不会出现在其他人的通知里。

**适用范围**：scan_issues.sh + scan_discussions.sh