### PR TITLE
fix: three-tier dedup (ACK + real reply + trigger)

### DIFF
--- a/scripts/modules/scan_discussions.sh
+++ b/scripts/modules/scan_discussions.sh
@@ -28,8 +28,11 @@ echo "$DISC_DATA" | jq -c "." | while read -r disc; do
   D_NUM=$(echo "$disc" | jq -r '.number')
   D_TITLE=$(echo "$disc" | jq -r '.title')
 
-  # 检查是否已有实质性回复（查作者是 agent/slug 的评论，不用内容查重）
-  HAS_REAL_REPLY=$(echo "$disc" | jq -r ".comments.nodes[] | select(.author.login == \"agent/${AGENT_SLUG}\") | .body" 2>/dev/null | wc -l)
+  # 两层查重：
+  # 1. 实质性回复（[@agent/taizi]）— agent 的正式报告，永久有效
+  # 2. ACK 通知（@agent/taizi 收到）— 一次性确认，发送后不再重复
+  HAS_REAL_REPLY=$(echo "$disc" | jq -r "[.comments.nodes[] | select(.body | contains(\"[@agent/${AGENT_SLUG}]\"))] | length" 2>/dev/null)
+  HAS_ACK=$(echo "$disc" | jq -r "[.comments.nodes[] | select(.body | contains(\"[@${AGENT_SLUG}]\") or (.body | contains(\"@${AGENT_SLUG}\") and .body | contains(\"收到\"))))] | length" 2>/dev/null)
 
   # 检查是否被艾特（标题+正文，不查评论避免自己触发自己）
   # @agent/all → 所有agent都要回，@agent/taizi → 只有我回
@@ -39,19 +42,26 @@ echo "$DISC_DATA" | jq -c "." | while read -r disc; do
   D_LABELS=$(echo "$disc" | jq -r ".labels.nodes[].name" 2>/dev/null)
   HAS_SKILL_ALL=$(echo "$D_LABELS" | grep -c "skill/all" || true)
 
-  echo "Discussion #$D_NUM: $D_TITLE"
-
   # 触发条件：被@ 或 有 skill/all label
   SHOULD_RESPOND=$((IS_TAGGED + HAS_SKILL_ALL))
 
-  # 场景1：触发 + 没回复过 → 发诚实通知
-  if [ "$SHOULD_RESPOND" -gt "0" ] && [ "$HAS_REAL_REPLY" -eq "0" ]; then
-    echo "  → 触发（tagged=${IS_TAGGED}, skill/all=${HAS_SKILL_ALL}），发通知"
+  echo "Discussion #$D_NUM: $D_TITLE"
+  echo "  → tagged=${IS_TAGGED}, skill/all=${HAS_SKILL_ALL}, real_reply=${HAS_REAL_REPLY}, ack=${HAS_ACK}"
+
+  # 场景1：有实质性回复 → 跳过
+  if [ "$HAS_REAL_REPLY" -gt "0" ]; then
+    echo "  → 有实质性回复，跳过"
+  # 场景2：触发 + 没 ACK → 发 ACK
+  elif [ "$SHOULD_RESPOND" -gt "0" ] && [ "$HAS_ACK" -eq "0" ]; then
+    echo "  → 触发，无 ACK，发通知"
     gh api graphql -f query='mutation($id:ID!,$body:String!){addDiscussionComment(input:{discussionId:$id,body:$body}){comment{id}}}' \
       -f id="$D_ID" -f body="@${AGENT_SLUG} 收到艾特，我来分析一下，有结果后汇报。" >/dev/null
-  # 场景2：没触发 → 跳过（不打扰）
+  # 场景3：触发 + 有 ACK → 跳过
+  elif [ "$SHOULD_RESPOND" -gt "0" ]; then
+    echo "  → 触发，已有 ACK，跳过"
+  # 场景4：没触发 → 跳过
   else
-    echo "  → 没被艾特且无 skill/all，跳过（不打扰）"
+    echo "  → 没被艾特且无 skill/all，跳过"
   fi
 done
 

--- a/scripts/modules/scan_issues.sh
+++ b/scripts/modules/scan_issues.sh
@@ -30,9 +30,13 @@ echo "$ISSUE_DATA" | jq -c ".[]" | while read -r issue; do
     continue
   fi
 
-  # 检查是否已有实质性回复（查作者是 agent/slug 的评论，不用内容查重）
+  # 两层查重：
+  # 1. 实质性回复（[@agent/taizi]）— agent 的正式报告，永久有效
+  # 2. ACK 通知（@agent/taizi 收到）— 一次性确认，发送后不再重复
   HAS_REAL_I_REPLY=$(gh issue view $I_NUM --json comments --jq \
     ".comments[] | select(.author.login == \"agent/${AGENT_SLUG}\") | .body" 2>/dev/null | wc -l)
+  HAS_ACK=$(gh issue view $I_NUM --json comments --jq \
+    "[.comments[] | select(.author.login == \"agent/${AGENT_SLUG}\" and (.body | contains(\"[@${AGENT_SLUG}]\") or (.body | contains(\"@${AGENT_SLUG}\") and .body | contains(\"收到\"))))] | length")
 
   # 检查是否被艾特（标题+正文）
   # @agent/all → 所有agent都要回，@agent/taizi → 只有我回
@@ -42,19 +46,26 @@ echo "$ISSUE_DATA" | jq -c ".[]" | while read -r issue; do
   # skill/all label 也视为被艾特（全员广播）
   HAS_SKILL_ALL=$(echo "$I_LABELS" | grep -c "skill/all" || true)
 
-  echo "Issue #$I_NUM: $I_TITLE"
-
   # 触发条件：被@ 或 有 skill/all label
   SHOULD_RESPOND=$((IS_TAGGED_ISSUE + HAS_SKILL_ALL))
 
-  # 场景1：触发 + 没回复过 → 发诚实通知 + 认领
-  if [ "$SHOULD_RESPOND" -gt "0" ] && [ "$HAS_REAL_I_REPLY" -eq "0" ]; then
-    echo "  → 触发（tagged=${IS_TAGGED_ISSUE}, skill/all=${HAS_SKILL_ALL}），认领 + 发通知"
+  echo "Issue #$I_NUM: $I_TITLE"
+  echo "  → tagged=${IS_TAGGED_ISSUE}, skill/all=${HAS_SKILL_ALL}, real_reply=${HAS_REAL_I_REPLY}, ack=${HAS_ACK}"
+
+  # 场景1：有实质性回复 → 跳过
+  if [ "$HAS_REAL_I_REPLY" -gt "0" ]; then
+    echo "  → 有实质性回复，跳过"
+  # 场景2：触发 + 没 ACK → 发 ACK + 认领
+  elif [ "$SHOULD_RESPOND" -gt "0" ] && [ "$HAS_ACK" -eq "0" ]; then
+    echo "  → 触发，无 ACK，认领 + 发通知"
     gh issue edit $I_NUM --add-label "task/processing,$IDENTITY_LABEL" --remove-label "task" 2>/dev/null
     gh issue comment $I_NUM --body="@${AGENT_SLUG} 收到任务，我来分析一下，有结果后向你汇报。" 2>/dev/null
-  # 场景2：没触发 + 没回复过 → 跳过（不打扰）
-  elif [ "$HAS_REAL_I_REPLY" -eq "0" ]; then
-    echo "  → 没被艾特且无 skill/all，跳过（不打扰）"
+  # 场景3：触发 + 有 ACK → 跳过（避免重复发 ACK）
+  elif [ "$SHOULD_RESPOND" -gt "0" ]; then
+    echo "  → 触发，已有 ACK，跳过"
+  # 场景4：没触发 → 跳过
+  else
+    echo "  → 没被艾特且无 skill/all，跳过"
   fi
 done
 


### PR DESCRIPTION
**问题**：只有 ACK 层查重不足，每次扫描都重复发"收到任务..."

**三层查重逻辑**：
1. `HAS_ACK`：@slug 收到... → 发过一次就不再发
2. `HAS_REAL_REPLY`：[@agent/slug] 实质性回复 → 发过就不再发
3. `SHOULD_RESPOND`：被@ 或 skill/all label → 必须满足才触发

**修复范围**：scan_issues.sh + scan_discussions.sh